### PR TITLE
Feature/replace big float by big rat

### DIFF
--- a/cmd/ethproof/ethproof.go
+++ b/cmd/ethproof/ethproof.go
@@ -34,14 +34,16 @@ func main() {
 	if tokenData.Decimals < 1 {
 		log.Fatal("decimals cannot be fetch")
 	}
+	decimals := int(tokenData.Decimals)
 	holderAddr := common.HexToAddress(*holder)
 
 	balance, err := ts.Balance(holderAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("contract:%s holder:%s balance:%s", *contract, *holder, balance.String())
-	if a, _ := balance.Uint64(); a == 0 {
+	log.Printf("contract:%s holder:%s balance:%s", *contract, *holder,
+		balance.FloatString(decimals))
+	if balance.Cmp(big.NewRat(0, 1)) == 0 {
 		log.Println("no amount for holder")
 		return
 	}
@@ -64,7 +66,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("storage data -> slot: %d amount: %s", slot, amount.String())
+	log.Printf("storage data -> slot: %d amount: %s", slot, amount.FloatString(decimals))
 
 	var blockNum *big.Int
 	if *height > 0 {
@@ -88,7 +90,7 @@ func main() {
 		if err != nil {
 			log.Printf("warning: %v", err)
 		}
-		log.Printf("balance on block %s: %s", block.String(), balance.String())
+		log.Printf("balance on block %s: %s", block.String(), balance.FloatString(decimals))
 		log.Printf("hex balance: %x\n", fullBalance.Bytes())
 		log.Printf("storage root: %x\n", sproof.StorageHash)
 		if err := minime.VerifyProof(
@@ -109,7 +111,8 @@ func main() {
 		if err != nil {
 			log.Printf("warning: %v", err)
 		}
-		log.Printf("mapbased balance on block %s: %s", block.Number().String(), balance.String())
+		log.Printf("mapbased balance on block %s: %s", block.Number().String(),
+			balance.FloatString(decimals))
 		if err := mapbased.VerifyProof(
 			common.HexToAddress(*holder),
 			sproof.StorageHash,

--- a/ethstorageproof/ethstorageproof_test.go
+++ b/ethstorageproof/ethstorageproof_test.go
@@ -3,7 +3,6 @@ package ethstorageproof
 import (
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -165,7 +164,6 @@ func TestVerify(t *testing.T) {
 			}
 		}
 
-		fmt.Printf("= %v -> %v\n", tt.value, value)
 		if vp, err := VerifyProof(crypto.Keccak256Hash(tt.proof[0]), tt.key,
 			value, tt.proof); vp != tt.verify {
 			t.Errorf("testcase %d: want %v, got %v (err: %v)\n", i, tt.verify, !tt.verify, err)

--- a/examples/generate-proofs/generateProofs.go
+++ b/examples/generate-proofs/generateProofs.go
@@ -21,11 +21,15 @@ func main() {
 	contract := flag.String("contract", "", "ERC20 contract address")
 	holderFile := flag.String("holderFile", "", "text file with holder addresses (separated by line)")
 	flag.Parse()
+	var contractAddr common.Address
+	if err := contractAddr.UnmarshalText([]byte(*contract)); err != nil {
+		log.Fatal(err)
+	}
 	data, err := ioutil.ReadFile(*holderFile)
 	if err != nil {
 		log.Fatal(err)
 	}
-	getProofs(*web3, *contract, strings.Split(string(data), "\n"))
+	getProofs(*web3, contractAddr, strings.Split(string(data), "\n"))
 }
 
 type EthProofs struct {
@@ -40,7 +44,7 @@ type HolderProof struct {
 	StorageProof ethstorageproof.StorageResult `json:"storageProof"`
 }
 
-func getProofs(web3, contract string, holders []string) {
+func getProofs(web3 string, contract common.Address, holders []string) {
 	t, err := token.NewToken(token.TokenTypeMapbased, contract, web3)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/verify-top-50-erc20/main.go
+++ b/examples/verify-top-50-erc20/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/storage-proofs-eth-go/ethstorageproof"
@@ -34,7 +35,7 @@ func main() {
 		log.Fatal(err)
 	}
 	log.Printf("contract:%s holder:%s balance:%s", *contract, *holder, balance.String())
-	if a, _ := balance.Uint64(); a == 0 {
+	if balance.Cmp(big.NewRat(0, 1)) == 0 {
 		log.Println("no amount for holder")
 		return
 	}

--- a/examples/verify-top-50-erc20/main.go
+++ b/examples/verify-top-50-erc20/main.go
@@ -18,9 +18,17 @@ func main() {
 	holder := flag.String("holder", "", "address of the token holder")
 	contractType := flag.String("type", "mapbased", "ERC20 contract type (mapbased, minime)")
 	flag.Parse()
+	var contractAddr common.Address
+	if err := contractAddr.UnmarshalText([]byte(*contract)); err != nil {
+		log.Fatal(err)
+	}
+	var holderAddr common.Address
+	if err := holderAddr.UnmarshalText([]byte(*holder)); err != nil {
+		log.Fatal(err)
+	}
 
 	ts := erc20.ERC20Token{}
-	ts.Init(context.Background(), *web3, *contract)
+	ts.Init(context.Background(), *web3, contractAddr)
 	tokenData, err := ts.GetTokenData()
 	if err != nil {
 		log.Fatal(err)
@@ -28,13 +36,12 @@ func main() {
 	if tokenData.Decimals < 1 {
 		log.Fatal("decimals cannot be fetch")
 	}
-	holderAddr := common.HexToAddress(*holder)
 
 	balance, err := ts.Balance(holderAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("contract:%s holder:%s balance:%s", *contract, *holder, balance.String())
+	log.Printf("contract:%v holder:%v balance:%s", contractAddr, holderAddr, balance.String())
 	if balance.Cmp(big.NewRat(0, 1)) == 0 {
 		log.Println("no amount for holder")
 		return
@@ -50,11 +57,11 @@ func main() {
 		log.Fatalf("token type not supported %s", *contractType)
 	}
 
-	t, err := token.NewToken(ttype, *contract, *web3)
+	t, err := token.NewToken(ttype, contractAddr, *web3)
 	if err != nil {
 		log.Fatal(err)
 	}
-	slot, amount, err := t.DiscoverSlot(common.HexToAddress(*holder))
+	slot, amount, err := t.DiscoverSlot(holderAddr)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/ethereum/go-ethereum v1.9.25
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
+	github.com/frankban/quicktest v1.13.0 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 // indirect
 	github.com/go-kit/kit v0.10.0 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/frankban/quicktest v1.7.2/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03DbaAcR7Ks/o=
+github.com/frankban/quicktest v1.13.0 h1:yNZif1OkDfNoDfb9zZa9aXIpejNR4F23Wely0c+Qdqk=
+github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -180,6 +182,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -263,6 +267,8 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	qt "github.com/frankban/quicktest"
 )
@@ -29,11 +30,28 @@ func TestValueToBalance(t *testing.T) {
 	}}
 	for i, v := range vectors {
 		value := hexutil.MustDecode(v.inputValue)
-		balance, ibalance, err := ValueToBalance(value, v.inputDecimals)
+		balance, ibalance := ValueToBalance(value, v.inputDecimals)
 		c.Run(fmt.Sprintf("i=%v", i), func(c *qt.C) {
-			c.Assert(err, qt.IsNil)
 			c.Check(balance.FloatString(v.inputDecimals), qt.Equals, v.outputBalance)
 			c.Check(ibalance.String(), qt.Equals, v.outputIBalance)
 		})
 	}
+}
+
+func TestGetMapSlot(t *testing.T) {
+	c := qt.New(t)
+
+	address := common.HexToAddress("0xbd9c69654b8f3e5978dfd138b00cb0be29f28ccf")
+	position := 1
+	mapSlot := GetMapSlot(address, position)
+	c.Check(common.Hash(mapSlot).Hex(), qt.Equals,
+		"0x4a985c9a291a06b2854315c3a75ca2c1065ef62e859e2534b655d306748c16d4")
+}
+
+func TestGetArraySlot(t *testing.T) {
+	c := qt.New(t)
+
+	arraySlot := GetArraySlot(3)
+	c.Check(common.Hash(arraySlot).Hex(), qt.Equals,
+		"0xc2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b")
 }

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -1,0 +1,39 @@
+package helpers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	qt "github.com/frankban/quicktest"
+)
+
+func TestValueToBalance(t *testing.T) {
+	c := qt.New(t)
+	type data struct {
+		inputValue     string
+		inputDecimals  int
+		outputBalance  string
+		outputIBalance string
+	}
+	vectors := []data{{
+		inputValue:     "0x00000000000293fb5ca8d27b5662e57700000000000000000000000000c304f2",
+		inputDecimals:  18,
+		outputBalance:  "1060549995705646568037077887575325019587292552.758520904839005426",
+		outputIBalance: "1060549995705646568037077887575325019587292552758520904839005426",
+	}, {
+		inputValue:     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		inputDecimals:  18,
+		outputBalance:  "115792089237316195423570985008687907853269984665640564039457.584007913129639935",
+		outputIBalance: "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+	}}
+	for i, v := range vectors {
+		value := hexutil.MustDecode(v.inputValue)
+		balance, ibalance, err := ValueToBalance(value, v.inputDecimals)
+		c.Run(fmt.Sprintf("i=%v", i), func(c *qt.C) {
+			c.Assert(err, qt.IsNil)
+			c.Check(balance.FloatString(v.inputDecimals), qt.Equals, v.outputBalance)
+			c.Check(ibalance.String(), qt.Equals, v.outputIBalance)
+		})
+	}
+}

--- a/token/erc20/erc20token.go
+++ b/token/erc20/erc20token.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"math"
 	"math/big"
 	"strings"
 
@@ -102,7 +101,7 @@ func (w *ERC20Token) GetTokenData() (*TokenData, error) {
 }
 
 // Balance returns the current address balance
-func (w *ERC20Token) Balance(address common.Address) (*big.Float, error) {
+func (w *ERC20Token) Balance(address common.Address) (*big.Rat, error) {
 	b, err := w.token.BalanceOf(&bind.CallOpts{}, address)
 	if err != nil {
 		return nil, err
@@ -111,10 +110,7 @@ func (w *ERC20Token) Balance(address common.Address) (*big.Float, error) {
 	if err != nil {
 		return nil, err
 	}
-	f := big.NewFloat(float64(0))
-	f.SetString(b.String())
-	f.Mul(f, big.NewFloat(1/(math.Pow10(int(decimals)))))
-	return f, nil
+	return helpers.BalanceToRat(b, int(decimals)), nil
 }
 
 // TokenName wraps the name() function contract call

--- a/token/erc20/token.go
+++ b/token/erc20/token.go
@@ -3,14 +3,16 @@ package erc20
 import (
 	"fmt"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type TokenData struct {
-	Address     string   `json:"address"`
-	Name        string   `json:"name"`
-	Symbol      string   `json:"symbol"`
-	Decimals    uint8    `json:"decimals"`
-	TotalSupply *big.Int `json:"totalSupply,omitempty"`
+	Address     common.Address `json:"address"`
+	Name        string         `json:"name"`
+	Symbol      string         `json:"symbol"`
+	Decimals    uint8          `json:"decimals"`
+	TotalSupply *big.Int       `json:"totalSupply,omitempty"`
 }
 
 func (t *TokenData) String() string {

--- a/token/mapbased/mapbased.go
+++ b/token/mapbased/mapbased.go
@@ -77,7 +77,7 @@ func (m *Mapbased) getMapProofWithIndexSlot(ctx context.Context, holder common.A
 // A token holder address must be provided in order to have a balance to search and compare.
 // Returns ErrSlotNotFound if the slot cannot be found.
 // If found, returns also the amount stored.
-func (m *Mapbased) DiscoverSlot(holder common.Address) (int, *big.Float, error) {
+func (m *Mapbased) DiscoverSlot(holder common.Address) (int, *big.Rat, error) {
 	var slot [32]byte
 	tokenData, err := m.erc20.GetTokenData()
 	if err != nil {
@@ -91,8 +91,7 @@ func (m *Mapbased) DiscoverSlot(holder common.Address) (int, *big.Float, error) 
 	addr := common.Address{}
 	copy(addr[:], m.erc20.TokenAddr[:20])
 
-	ubalance, _ := balance.Uint64()
-	amount := big.NewFloat(0)
+	var amount *big.Rat
 	index := -1
 	for i := 0; i < DiscoveryIterations; i++ {
 		// Prepare storage index
@@ -109,12 +108,12 @@ func (m *Mapbased) DiscoverSlot(holder common.Address) (int, *big.Float, error) 
 		}
 
 		// Parse balance value
-		amount, _, err := helpers.ValueToBalance(value, int(tokenData.Decimals))
+		amount, _, err = helpers.ValueToBalance(value, int(tokenData.Decimals))
 		if err != nil {
 			continue
 		}
 		// Check if balance matches
-		if a, _ := amount.Uint64(); a == ubalance {
+		if amount.Cmp(balance) == 0 {
 			index = i
 			break
 		}

--- a/token/minime/helpers.go
+++ b/token/minime/helpers.go
@@ -2,7 +2,6 @@ package minime
 
 import (
 	"fmt"
-	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -102,16 +101,12 @@ func VerifyProof(holder common.Address, storageRoot common.Hash,
 // Returns the float balance (taking into account the decimals), the full
 // integer without taking into account the decimals and the Ethereum block
 // number for the checkpoint.
-func ParseMinimeValue(value []byte, decimals int) (*big.Float, *big.Int, *big.Int, error) {
+func ParseMinimeValue(value []byte, decimals int) (*big.Rat, *big.Int, *big.Int, error) {
 	// hexValue could be left zeroes trimed, so we need to expand it to 32 bytes
 	value = common.LeftPadBytes(value, 32)
-	mblock := new(big.Int).SetBytes(common.TrimLeftZeroes(value[16:]))
-	ibalance, _ := new(big.Int).SetString(fmt.Sprintf("%x", value[:16]), 16)
-	balance := new(big.Float)
-	if _, ok := balance.SetString(fmt.Sprintf("0x%x", value[:16])); !ok {
-		return nil, nil, nil, fmt.Errorf("amount cannot be parsed")
-	}
-	balance.Mul(balance, big.NewFloat(1/(math.Pow10(decimals))))
+	mblock := new(big.Int).SetBytes(value[16:])
+	ibalance := new(big.Int).SetBytes(value[:16])
+	balance := helpers.BalanceToRat(ibalance, decimals)
 	return balance, ibalance, mblock, nil
 }
 

--- a/token/minime/helpers_test.go
+++ b/token/minime/helpers_test.go
@@ -32,9 +32,8 @@ func TestParseMinimeValue(t *testing.T) {
 	}}
 	for i, v := range vectors {
 		value := hexutil.MustDecode(v.inputValue)
-		balance, ibalance, mblock, err := ParseMinimeValue(value, v.inputDecimals)
+		balance, ibalance, mblock := ParseMinimeValue(value, v.inputDecimals)
 		c.Run(fmt.Sprintf("i=%v", i), func(c *qt.C) {
-			c.Assert(err, qt.IsNil)
 			c.Check(balance.FloatString(v.inputDecimals), qt.Equals, v.outputBalance)
 			c.Check(ibalance.String(), qt.Equals, v.outputIBalance)
 			c.Check(mblock.String(), qt.Equals, v.outputBlock)

--- a/token/minime/helpers_test.go
+++ b/token/minime/helpers_test.go
@@ -1,0 +1,43 @@
+package minime
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	qt "github.com/frankban/quicktest"
+)
+
+func TestParseMinimeValue(t *testing.T) {
+	c := qt.New(t)
+	type data struct {
+		inputValue     string
+		inputDecimals  int
+		outputBalance  string
+		outputIBalance string
+		outputBlock    string
+	}
+	vectors := []data{{
+		inputValue:     "0x00000000000293fb5ca8d27b5662e57700000000000000000000000000c304f2",
+		inputDecimals:  18,
+		outputBalance:  "3116676.321791472042173815",
+		outputIBalance: "3116676321791472042173815",
+		outputBlock:    "12780786",
+	}, {
+		inputValue:     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		inputDecimals:  18,
+		outputBalance:  "340282366920938463463.374607431768211455",
+		outputIBalance: "340282366920938463463374607431768211455",
+		outputBlock:    "340282366920938463463374607431768211455",
+	}}
+	for i, v := range vectors {
+		value := hexutil.MustDecode(v.inputValue)
+		balance, ibalance, mblock, err := ParseMinimeValue(value, v.inputDecimals)
+		c.Run(fmt.Sprintf("i=%v", i), func(c *qt.C) {
+			c.Assert(err, qt.IsNil)
+			c.Check(balance.FloatString(v.inputDecimals), qt.Equals, v.outputBalance)
+			c.Check(ibalance.String(), qt.Equals, v.outputIBalance)
+			c.Check(mblock.String(), qt.Equals, v.outputBlock)
+		})
+	}
+}

--- a/token/minime/minime.go
+++ b/token/minime/minime.go
@@ -39,7 +39,7 @@ func (m *Minime) GetBlock(block *big.Int) (*types.Block, error) {
 }
 
 // DiscoverSlot tries to find the map index slot for the minime balances
-func (m *Minime) DiscoverSlot(holder common.Address) (int, *big.Float, error) {
+func (m *Minime) DiscoverSlot(holder common.Address) (int, *big.Rat, error) {
 	balance, err := m.erc20.Balance(holder)
 	if err != nil {
 		return -1, nil, err
@@ -47,7 +47,7 @@ func (m *Minime) DiscoverSlot(holder common.Address) (int, *big.Float, error) {
 
 	addr := common.Address{}
 	copy(addr[:], m.erc20.TokenAddr[:20])
-	amount := big.NewFloat(0)
+	var amount *big.Rat
 	var block *big.Int
 	index := -1
 
@@ -73,8 +73,7 @@ func (m *Minime) DiscoverSlot(holder common.Address) (int, *big.Float, error) {
 		}
 
 		// Check if balance matches
-		a, _ := amount.Uint64()
-		if b, _ := balance.Uint64(); b == a {
+		if amount.Cmp(balance) == 0 {
 			index = i
 			break
 		}
@@ -137,7 +136,7 @@ func (m *Minime) GetProof(holder common.Address, block *big.Int,
 				if err != nil {
 					return nil, err
 				}
-				if b, _ := balance.Uint64(); b > 0 {
+				if balance.Cmp(big.NewRat(0, 1)) == 1 {
 					return nil, fmt.Errorf("proof of nil has a balance value")
 				}
 				if block.Uint64() > 0 {
@@ -165,7 +164,7 @@ func (m *Minime) VerifyProof(holder common.Address, storageRoot common.Hash,
 // getMinimeAtPosition returns the data contained in a specific checkpoint array position,
 // returns the balance, the checkpoint block and the merkle tree key slot
 func (m *Minime) getMinimeAtPosition(holder common.Address, mapIndexSlot,
-	position int, block *big.Int) (*big.Float, *big.Int, *common.Hash, error) {
+	position int, block *big.Int) (*big.Rat, *big.Int, *common.Hash, error) {
 	token, err := m.erc20.GetTokenData()
 	if err != nil {
 		return nil, nil, nil, err

--- a/token/token.go
+++ b/token/token.go
@@ -18,7 +18,7 @@ const (
 
 type Token interface {
 	Init(tokenAddress, web3endpoint string) error
-	DiscoverSlot(holder common.Address) (int, *big.Float, error)
+	DiscoverSlot(holder common.Address) (int, *big.Rat, error)
 	GetProof(holder common.Address, block *big.Int,
 		indexSlot int) (*ethstorageproof.StorageProof, error)
 	GetBlock(block *big.Int) (*types.Block, error)

--- a/token/token.go
+++ b/token/token.go
@@ -17,7 +17,7 @@ const (
 )
 
 type Token interface {
-	Init(tokenAddress, web3endpoint string) error
+	Init(tokenAddress common.Address, web3endpoint string) error
 	DiscoverSlot(holder common.Address) (int, *big.Rat, error)
 	GetProof(holder common.Address, block *big.Int,
 		indexSlot int) (*ethstorageproof.StorageProof, error)
@@ -27,7 +27,7 @@ type Token interface {
 		targetBlock *big.Int) error
 }
 
-func NewToken(tokenType int, address, web3endpoint string) (Token, error) {
+func NewToken(tokenType int, address common.Address, web3endpoint string) (Token, error) {
 	var t Token
 	switch tokenType {
 	case TokenTypeMapbased:


### PR DESCRIPTION
### Replace big.Float by big.Rat for balances

big.Float encodes floats in binary as a mantissa and exponent.  Since
balances as reals are calculated by dividing by powers of 10, the
non-integer part sometimes can't be represented in binary with finite
precission, leading to losing precission.  Using big.Rat allows us to
represent the balance with decimals without losing precision.

### Only use hex strings at the edge

Work always with byte slices in all functions that deal with trie keys,
trie values, addresses; except at the edges (network, user
input/output) where hex strings are necessary.

Resolve #7 

I have also introduced some test that use quicktest, but I haven't done the migration of the already existing tests.