### PR TITLE
Expose ctx, call GetBlock internally

### DIFF
--- a/cmd/ethproof/ethproof.go
+++ b/cmd/ethproof/ethproof.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"log"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/storage-proofs-eth-go/helpers"
@@ -32,11 +33,13 @@ func main() {
 		log.Fatal(err)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
 	ts := erc20.ERC20Token{}
 	if err := ts.Init(context.Background(), *web3, contractAddr); err != nil {
 		log.Fatal(err)
 	}
-	tokenData, err := ts.GetTokenData()
+	tokenData, err := ts.GetTokenData(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -45,7 +48,7 @@ func main() {
 	}
 	decimals := int(tokenData.Decimals)
 
-	balance, err := ts.Balance(holderAddr)
+	balance, err := ts.Balance(ctx, holderAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -66,11 +69,11 @@ func main() {
 		log.Fatalf("token type not supported %s", *contractType)
 	}
 
-	t, err := token.NewToken(ttype, contractAddr, *web3)
+	t, err := token.NewToken(ctx, ttype, contractAddr, *web3)
 	if err != nil {
 		log.Fatal(err)
 	}
-	slot, amount, err := t.DiscoverSlot(holderAddr)
+	slot, amount, err := t.DiscoverSlot(ctx, holderAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -84,7 +87,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	sproof, err := t.GetProof(holderAddr, block.Number(), slot)
+	sproof, err := t.GetProof(ctx, holderAddr, block.Number(), slot)
 	if err != nil {
 		log.Fatalf("cannot get proof: %v", err)
 	}

--- a/examples/verify-top-50-erc20/main.go
+++ b/examples/verify-top-50-erc20/main.go
@@ -27,9 +27,10 @@ func main() {
 		log.Fatal(err)
 	}
 
+	ctx := context.Background()
 	ts := erc20.ERC20Token{}
-	ts.Init(context.Background(), *web3, contractAddr)
-	tokenData, err := ts.GetTokenData()
+	ts.Init(ctx, *web3, contractAddr)
+	tokenData, err := ts.GetTokenData(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -37,7 +38,7 @@ func main() {
 		log.Fatal("decimals cannot be fetch")
 	}
 
-	balance, err := ts.Balance(holderAddr)
+	balance, err := ts.Balance(ctx, holderAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -57,11 +58,11 @@ func main() {
 		log.Fatalf("token type not supported %s", *contractType)
 	}
 
-	t, err := token.NewToken(ttype, contractAddr, *web3)
+	t, err := token.NewToken(ctx, ttype, contractAddr, *web3)
 	if err != nil {
 		log.Fatal(err)
 	}
-	slot, amount, err := t.DiscoverSlot(holderAddr)
+	slot, amount, err := t.DiscoverSlot(ctx, holderAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -71,7 +72,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	sproof, err := t.GetProof(holderAddr, block.Number(), slot)
+	sproof, err := t.GetProof(ctx, holderAddr, block.Number(), slot)
 	if err != nil {
 		log.Fatalf("cannot get proof: %v", err)
 	}

--- a/token/token.go
+++ b/token/token.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
@@ -17,27 +18,28 @@ const (
 )
 
 type Token interface {
-	Init(tokenAddress common.Address, web3endpoint string) error
-	DiscoverSlot(holder common.Address) (int, *big.Rat, error)
-	GetProof(holder common.Address, block *big.Int,
+	Init(ctx context.Context, tokenAddress common.Address, web3endpoint string) error
+	DiscoverSlot(ctx context.Context, holder common.Address) (int, *big.Rat, error)
+	GetProof(ctx context.Context, holder common.Address, block *big.Int,
 		indexSlot int) (*ethstorageproof.StorageProof, error)
-	GetBlock(block *big.Int) (*types.Block, error)
+	GetBlock(ctx context.Context, block *big.Int) (*types.Block, error)
 	VerifyProof(holder common.Address, storageRoot common.Hash,
 		proofs []ethstorageproof.StorageResult, indexSlot int, targetBalance,
 		targetBlock *big.Int) error
 }
 
-func NewToken(tokenType int, address common.Address, web3endpoint string) (Token, error) {
+func NewToken(ctx context.Context, tokenType int, address common.Address,
+	web3endpoint string) (Token, error) {
 	var t Token
 	switch tokenType {
 	case TokenTypeMapbased:
 		t = new(mapbased.Mapbased)
-		if err := t.Init(address, web3endpoint); err != nil {
+		if err := t.Init(ctx, address, web3endpoint); err != nil {
 			return nil, err
 		}
 	case TokenTypeMinime:
 		t = new(minime.Minime)
-		if err := t.Init(address, web3endpoint); err != nil {
+		if err := t.Init(ctx, address, web3endpoint); err != nil {
 			return nil, err
 		}
 	default:


### PR DESCRIPTION
Expose the context.Context as an input argument to all the functions so
that the user of the package can decide the proper context to use,
instead of having a hardcoded timeout.

In functions that require block data, make a call to GetBlock internally
instead of expecting a block data as input (now they take a *big.Int for
block number as input)