### PR TITLE
Simplify Token interface

### DIFF
--- a/token/erc20/token.go
+++ b/token/erc20/token.go
@@ -16,6 +16,6 @@ type TokenData struct {
 }
 
 func (t *TokenData) String() string {
-	return fmt.Sprintf(`{"name":%s,"symbol":%s,"decimals":%s,"totalSupply":%s}`,
-		t.Name, t.Symbol, string(t.Decimals), t.TotalSupply.String())
+	return fmt.Sprintf(`{"name":%s,"symbol":%s,"decimals":%v,"totalSupply":%v}`,
+		t.Name, t.Symbol, t.Decimals, t.TotalSupply)
 }

--- a/token/mapbased/mapbased.go
+++ b/token/mapbased/mapbased.go
@@ -110,10 +110,7 @@ func VerifyProof(holder common.Address, storageRoot common.Hash,
 		return fmt.Errorf("value is nil")
 	}
 	if len(proof.Key) != 32 {
-		return fmt.Errorf("key length is wrong (%d)", len(proof.Key))
-	}
-	if len(proof.Proof) < 4 {
-		return fmt.Errorf("proof length is wrong")
+		return fmt.Errorf("key length is wrong.  Expected 32, got %v", len(proof.Key))
 	}
 	if targetBalance == nil {
 		return fmt.Errorf("target balance is nil")

--- a/token/minime/helpers.go
+++ b/token/minime/helpers.go
@@ -50,8 +50,8 @@ func VerifyProof(holder common.Address, storageRoot common.Hash,
 	_, proof0Balance, proof0Block := ParseMinimeValue(proofs[0].Value, 1)
 	// Check balance matches with the provided balance
 	if proof0Balance.Cmp(targetBalance) != 0 {
-		return fmt.Errorf("proof balance and provided balance mismatch (%s != %s)",
-			proof0Balance.String(), targetBalance.String())
+		return fmt.Errorf("proof balance and provided balance mismatch (%v != %v)",
+			proof0Balance, targetBalance)
 	}
 
 	// Verify that `proof0Block <= targetBlock < proof1Block`

--- a/token/minime/helpers.go
+++ b/token/minime/helpers.go
@@ -28,10 +28,7 @@ func VerifyProof(holder common.Address, storageRoot common.Hash,
 				len(p.Value))
 		}
 		if len(p.Key) != 32 {
-			return fmt.Errorf("key length is wrong (%d)", len(p.Key))
-		}
-		if len(p.Proof) < 4 {
-			return fmt.Errorf("proof length is wrong")
+			return fmt.Errorf("key length is wrong.  Expected 32, got %v", len(p.Key))
 		}
 	}
 	if targetBalance == nil {

--- a/token/token.go
+++ b/token/token.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/vocdoni/storage-proofs-eth-go/ethstorageproof"
 	"github.com/vocdoni/storage-proofs-eth-go/token/mapbased"
 	"github.com/vocdoni/storage-proofs-eth-go/token/minime"
@@ -18,32 +18,22 @@ const (
 )
 
 type Token interface {
-	Init(ctx context.Context, tokenAddress common.Address, web3endpoint string) error
 	DiscoverSlot(ctx context.Context, holder common.Address) (int, *big.Rat, error)
 	GetProof(ctx context.Context, holder common.Address, block *big.Int,
 		indexSlot int) (*ethstorageproof.StorageProof, error)
-	GetBlock(ctx context.Context, block *big.Int) (*types.Block, error)
 	VerifyProof(holder common.Address, storageRoot common.Hash,
 		proofs []ethstorageproof.StorageResult, indexSlot int, targetBalance,
 		targetBlock *big.Int) error
 }
 
-func NewToken(ctx context.Context, tokenType int, address common.Address,
-	web3endpoint string) (Token, error) {
-	var t Token
+func New(ctx context.Context, rpcCli *rpc.Client, tokenType int,
+	address common.Address) (Token, error) {
 	switch tokenType {
 	case TokenTypeMapbased:
-		t = new(mapbased.Mapbased)
-		if err := t.Init(ctx, address, web3endpoint); err != nil {
-			return nil, err
-		}
+		return mapbased.New(ctx, rpcCli, address)
 	case TokenTypeMinime:
-		t = new(minime.Minime)
-		if err := t.Init(ctx, address, web3endpoint); err != nil {
-			return nil, err
-		}
+		return minime.New(ctx, rpcCli, address)
 	default:
 		return nil, fmt.Errorf("tokentype %d unknown", tokenType)
 	}
-	return t, nil
 }


### PR DESCRIPTION
Remove Init and GetBlock functions from Token interface

Replace Init token functions by constructors

Pass rpc.Client to token constructor instead of web3 URL string