### PR TITLE
Feature/smallfixes

### DIFF
--- a/cmd/ethproof/ethproof.go
+++ b/cmd/ethproof/ethproof.go
@@ -50,9 +50,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if tokenData.Decimals < 1 {
-		log.Fatal("decimals cannot be fetch")
-	}
 	decimals := int(tokenData.Decimals)
 
 	balance, err := ts.Balance(ctx, holderAddr)

--- a/token/minime/helpers.go
+++ b/token/minime/helpers.go
@@ -19,8 +19,9 @@ func VerifyProof(holder common.Address, storageRoot common.Hash,
 	if len(proofs) != 2 {
 		return fmt.Errorf("wrong length of storage proofs")
 	}
-	for _, p := range proofs {
-		if p.Value == nil {
+	for i, p := range proofs {
+		// proofs[1].Value can be nil when it's a non-existence proof
+		if i == 0 && p.Value == nil {
 			return fmt.Errorf("value is nil")
 		}
 		if len(p.Value) > 32 {


### PR DESCRIPTION
These are two small updates required to add minime census in vocdoni-node.  Allowing the proof1.Value to be nil is OK in minime proofs because in general in go `[]byte{}` can be treated as `nil`.  And in particular, protobuf unmarshals a 0-length `bytes` as `nil` instead of `[]byte{}`.